### PR TITLE
Run mypy via CI

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Typecheck
     steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
       - name: mypy Typecheck
         uses: jpetrucciani/mypy-check@master
         with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,17 @@
+name: mypy Typecheck
+
+on: [push, pull_request]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    name: Typecheck
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: mypy Typecheck
+        uses: jpetrucciani/mypy-check@master

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Typecheck
     steps:
-      - name: Check out source repository
-        uses: actions/checkout@v3
       - name: mypy Typecheck
         uses: jpetrucciani/mypy-check@master
         with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
       - name: mypy Typecheck
         uses: jpetrucciani/mypy-check@master
+        with:
+          python_version: "3.11"


### PR DESCRIPTION
This enables the "Mypy Check" GitHub Action.

https://github.com/marketplace/actions/mypy-check

I'm using `@master` instead of a tag, because the latest tag is 0.971, whereas master seems possibly to update to new stable mypy versions more often.

The documentation says:

> Make sure you have a mypy.ini or setup.cfg file at the root of your repository!

But I'm hoping I may not need to do that here, because I'm using the default configuration. (Running mypy manually, on this repository, does not require any configuration file.)