### PR TITLE
Help CodeQL find Python dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,13 @@ jobs:
         java-version: 19
 
     - if: matrix.language == 'python'
-      name: Help CodeQL find dependencies
+      name: Set up Python environment
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - if: matrix.language == 'python'
+      name: Help CodeQL find Python dependencies
       run: ln -st . python/Pipfile{,.lock}
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,12 @@ jobs:
       with:
         python-version: '3.11'
 
+    - if: matrix.language == 'python'
+      name: Install Python dependencies
+      run: |
+        cd python
+        pipenv install
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,10 @@ jobs:
         distribution: 'temurin'
         java-version: 19
 
+    - if: matrix.language == 'python'
+      name: Help CodeQL find dependencies
+      run: ln -st . python/Pipfile{,.lock}
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,10 +64,10 @@ jobs:
       run: pip install -U pipenv
 
     - if: matrix.language == 'python'
-      name: Install Python dependencies
+      name: Determine Python dependencies
       run: |
         cd python
-        pipenv install
+        pipenv requirements >../requirements.txt
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,14 @@ jobs:
         python-version: '3.11'
 
     - if: matrix.language == 'python'
+      name: Update PyPA packages
+      run: pip install -U pip setuptools wheel
+
+    - if: matrix.language == 'python'
+      name: Install pipenv
+      run: pip install -U pipenv
+
+    - if: matrix.language == 'python'
       name: Install Python dependencies
       run: |
         cd python

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,10 +55,6 @@ jobs:
       with:
         python-version: '3.11'
 
-    - if: matrix.language == 'python'
-      name: Help CodeQL find Python dependencies
-      run: ln -st . python/Pipfile{,.lock}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
This installs Python 3.11 for CodeQL to use, and also works around the problem that CodeQL doesn't use the manifest files `Pipenv` and `Pipenv.lock` in the `python/` subdirectory.