### PR TITLE
Update ruby dependencies

### DIFF
--- a/compare/Gemfile.lock
+++ b/compare/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     rainbow (3.1.1)
     regexp_parser (2.7.0)
     rexml (3.2.5)
-    rubocop (1.46.0)
+    rubocop (1.48.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -21,9 +21,9 @@ GEM
       rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.26.0)
+    rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     unicode-display_width (2.4.2)
 
 PLATFORMS


### PR DESCRIPTION
These are the dependencies for the compare script `compare/check.rb`.

(The script still runs fine without them; they support rubocop.)