### PR TITLE
Update Python and Ruby dependencies monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/python"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/compare"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20


### PR DESCRIPTION
This only affects version updates from dependabot (not manual updates, and it shouldn't affect dependabot security updates either). It changes the schedule from weekly to monthly for Python and Ruby dependencies.