### PR TITLE
Set minimum requests version in environment.yml

### DIFF
--- a/python/environment.yml
+++ b/python/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - ipykernel
   - numpy
   - openai
-  - requests
+  - requests>=2.31.0
   - tabulate
 
   # Development tools


### PR DESCRIPTION
I'm not pinning dependencies in environment.yml, and most of them do not give version constraints. For requests, I think it makes sense to constrain the version to be at least 2.30.0, so that a version affected by CVE-2023-32681 is never used accidentally.

See #126 for where a roughly corresponding change was made for pipenv dependencies in Pipfile.lock (where it was much more important, because those are pinned, so pipenv would install a vulnerable version before that).