### PR TITLE
Fix JSON injection vulnerabilty in demo script

### DIFF
--- a/shell/demo
+++ b/shell/demo
@@ -20,36 +20,42 @@
 #
 # If the text to embed is omitted, a sample phrase is used instead.
 #
-# This script is just a demonstration. It is vulnerable to JSON injection and
-# thus unsuitable for use on untrusted input: if the input contains a '"'
-# character, then what comes after it can specify arbitrary JSON. This could be
-# exploited in undesirable ways, such as to specify a more expensive model.
-#
-# The other reason the code in this script probably couldn't be used unchanged
-# in production is that it assumes the request succeeds. If the request fails,
+# As written, this script assumes the request succeeds. If the request fails,
 # whatever it returned is nonetheless treated as a sequence of coordinates.
 
 set -e
 
 api_key() {
     local key="$OPENAI_API_KEY"
-    [ -n "$key" ] || key="$(<../.api_key)" # Fall back to reading .api_key.
+    [ -n "$key" ] || key="$(<../.api_key)"  # Fall back to reading .api_key.
     printf '%s\n' "$key"
 }
 
 # Compare https://beta.openai.com/docs/guides/embeddings/how-to-get-embeddings.
 # (In "Example: Getting embeddings", select "curl" instead of "python".)
+# Requires curl and jq to be installed.
 make_request() {
     local text="$*"
     printf '%s\n\n' "$text" >&2
 
+    # Build the JSON with jq --arg, since building it with parameter expansion
+    # results in a JSON injection vulnerability where the input text could
+    # contain a sequence like '", "injected_key": "injected_value'. Because
+    # input_text is a jq variable, not a shell variable, we must use single
+    # quotes around the code, so the shell doesn't expand $input_text. (We can
+    # call both 'text' but then if we mistakenly used double quotes, everything
+    # would seem to work but we'd get the injection bug we're trying to avoid.)
+    jq -n --arg input_text "$text" '{
+        "input": $input_text,
+        "model": "text-embedding-ada-002",
+        "encoding_format": "base64"
+    }' |
+    # Make the API call with the safely jq-constructed JSON.
     curl https://api.openai.com/v1/embeddings \
         -X POST \
         -H "Authorization: Bearer $(api_key)" \
         -H "Content-Type: application/json" \
-        -d '{"input": "'"$text"'",
-            "model": "text-embedding-ada-002",
-            "encoding_format": "base64"}'
+        -d @-
 
     printf '\n' >&2
 }

--- a/shell/demo
+++ b/shell/demo
@@ -23,12 +23,12 @@
 # As written, this script assumes the request succeeds. If the request fails,
 # whatever it returned is nonetheless treated as a sequence of coordinates.
 
-set -e
+set -eu
 
+# Write the OpenAI API key to standard output. (Because the key is sensitive,
+# this should typically be redirected, piped, or used in command substitution.)
 api_key() {
-    local key="$OPENAI_API_KEY"
-    [ -n "$key" ] || key="$(<../.api_key)"  # Fall back to reading .api_key.
-    printf '%s\n' "$key"
+    printf '%s\n' "${OPENAI_API_KEY:-$(<../.api_key)}"
 }
 
 # Compare https://beta.openai.com/docs/guides/embeddings/how-to-get-embeddings.

--- a/shell/demo-short
+++ b/shell/demo-short
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: 0BSD
-# Like demo, this script (demo-short) shouldn't be used on untrusted input.
+#
+# This script (demo-short) shouldn't be used on untrusted input, because of the
+# way parameter expansion is used in the curl -d "..." operand. This is to show
+# what the API call looks like, but it is insecure to do it this way unless you
+# have total control over the input. Instead, use "jq --arg" or a similar
+# technique to build the input, as shown in the "demo" (non-short) script.
 
 make_request() {
     curl https://api.openai.com/v1/embeddings \


### PR DESCRIPTION
Closes #193

This makes the full length demo script, `shell/demo`, more robust. In contrast, it does not change the behavior of the short demo script `shell/demo-short`, which is modified only to update the way its relationship to `shell/demo` is described (now that they are not both subject to JSON injection, but only the short one).

Although the vulnerability was documented and clearly warned about in the comments in `shell/demo`, the point of that longer script is to show the technique in somewhat more production-like code. So it never really made sense for it to be that brittle. This fixes that, by using `jq` to build the JSON in a way that automatically applies proper escaping sufficient even for adversarial input.

This is still not fully production quality, nor is it intended to be. Clarity of presentation remains the primary goal. The request is assumed to succeed, and short but uninformative output still results if the request fails due to an absent or invalid API key or for any other reason.