### PR TITLE
Change link for info on base64 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The example code in this repository is in three directories:
 - [In Bash](shell/README.md), using
   [`curl`](https://curl.se/docs/manpage.html),
   [`jq`](https://stedolan.github.io/jq/manual/), and
-  [`base64`](https://linux.die.net/man/1/base64). See the shell scripts
+  [`base64`](https://ss64.com/bash/base64.html). See the shell scripts
   [`demo`](shell/demo) and [`demo-short`](shell/demo-short).
 
 - [In Python](python/README.md), using

--- a/shell/README.md
+++ b/shell/README.md
@@ -4,7 +4,7 @@ Base64-encoded OpenAI embeddings **in Bash**.
 
 Uses
 [`curl`](https://curl.se/docs/manpage.html),[`jq`](https://stedolan.github.io/jq/manual/),
-and [`base64`](https://linux.die.net/man/1/base64).
+and [`base64`](https://ss64.com/bash/base64.html).
 
 Versions of these scripts are also available in [this
 gist](https://gist.github.com/EliahKagan/97e4b60c5c77f062c41e34bd42ec75f8).

--- a/why.md
+++ b/why.md
@@ -326,7 +326,7 @@ requesting them from the API endpoint, in three languages:
 - [In Bash](shell/README.md), using
   [`curl`](https://curl.se/docs/manpage.html),
   [`jq`](https://stedolan.github.io/jq/manual/), and
-  [`base64`](https://linux.die.net/man/1/base64). See the shell scripts
+  [`base64`](https://ss64.com/bash/base64.html). See the shell scripts
   [`demo`](shell/demo) and [`demo-short`](shell/demo-short).
 
 - [In Python](python/README.md), using


### PR DESCRIPTION
To a different page that includes examples.

This also fixes [recent problems checking the old link](https://github.com/EliahKagan/embed-encode/actions/runs/6207311430/job/16855581419#step:4:151), but that would not, by itself, be sufficient to justify this change.

In the future it might be possible to improve this further if there is a good page that documents it in a way that is not specific to the implementation provided by GNU coreutils (which both the old and new link are specific to).