### PR TITLE
Have Dependabot open grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: "maven"
     directory: "/java"
@@ -15,6 +18,9 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
+    groups:
+      java-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: "bundler"
     directory: "/compare"
@@ -23,6 +29,9 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
+    groups:
+      ruby-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
For Python, Java, and Ruby dependencies, with one group each.

GitHub Actions dependencies remain ungrouped. This also of course affects only Dependabot version updates, not Dependabot security updates (which are opened immediately, and individually when available).